### PR TITLE
Trie optimization

### DIFF
--- a/jamal-plantuml/src/main/java/javax0/jamal/plantuml/PlantUml.java
+++ b/jamal-plantuml/src/main/java/javax0/jamal/plantuml/PlantUml.java
@@ -7,9 +7,9 @@ import javax0.jamal.api.Macro;
 import javax0.jamal.api.Processor;
 import javax0.jamal.tools.Cache;
 import javax0.jamal.tools.FileTools;
+import javax0.jamal.tools.IndexedPlaceHolders;
 import javax0.jamal.tools.InputHandler;
 import javax0.jamal.tools.Params;
-import javax0.jamal.tools.PlaceHolders;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.SourceStringReader;
@@ -22,6 +22,12 @@ import java.net.MalformedURLException;
 import java.util.Map;
 
 public class PlantUml implements Macro, InnerScopeDependent {
+    private static class Trie {
+        static IndexedPlaceHolders formatter = IndexedPlaceHolders.with(
+                "$file"
+        );
+    }
+
     @Override
     public String evaluate(Input in, Processor processor) throws BadSyntax {
         final var root = Params.<String>holder("pu$folder", "folder").orElse("./");
@@ -49,7 +55,7 @@ public class PlantUml implements Macro, InnerScopeDependent {
             if (erred) {
                 throw new BadSyntax("There was an error processing diagram for '" + fileName + "' in PlantUml.");
             }
-            return PlaceHolders.with("$file", fileName).format(template.get());
+            return Trie.formatter.format(template.get(), fileName);
         } catch (Exception e) {
             throw new BadSyntax("PlantUml diagram '" + fileName + "'cannot be created.", e);
         }
@@ -132,8 +138,8 @@ public class PlantUml implements Macro, InnerScopeDependent {
         var umlText = in.toString();
         if (umlText.length() > 0 && umlText.charAt(0) != '@') {
             umlText = "@startuml\n" +
-                umlText +
-                "@enduml\n";
+                    umlText +
+                    "@enduml\n";
         }
         return umlText;
     }

--- a/jamal-snippet/README.adoc
+++ b/jamal-snippet/README.adoc
@@ -2013,7 +2013,7 @@ will result
 - Format.java: 930 bytes
 - Update.java: 3,754 bytes
 - SnipTransform.java: 14,199 bytes
-- FilesMacro.java: 4,883 bytes
+- FilesMacro.java: 5,196 bytes
 - Collect.java: 7,848 bytes
 - SnipFile.java: 680 bytes
 - TrimLines.java: 4,179 bytes
@@ -2030,7 +2030,7 @@ will result
 - KillLines.java: 2,019 bytes
 - SnipLoad.java: 3,530 bytes
 - SnippetStore.java: 10,174 bytes
-- ListDir.java: 5,321 bytes
+- ListDir.java: 5,583 bytes
 - XmlFormat.java: 3,536 bytes
 - SnippetXmlReader.java: 6,607 bytes
 - XmlInsert.java: 6,199 bytes
@@ -2039,7 +2039,7 @@ will result
 - CounterMacro.java: 1,811 bytes
 - SnipList.java: 1,260 bytes
 - XmlDocument.java: 5,656 bytes
-- Java.java: 9,275 bytes
+- Java.java: 10,404 bytes
 - ReplaceLines.java: 3,015 bytes
 - SkipLines.java: 2,544 bytes
 - SnipCheck.java: 5,619 bytes
@@ -2297,7 +2297,7 @@ will result in the output
 
 [source]
 ----
-2022-01-24 09:50:29
+2022-01-24 18:51:24
 ----
 
 
@@ -2399,11 +2399,11 @@ When Jamal processes this file it will generate `README.adoc`.
 In the format you can use the following placeholders:
 
 
+
 * `$name` gives the name of the file as was specified on the macro
 * `$absolutePath` the absolute path to the file
 * `$parent` the parent directory where the file is
 * `$simpleName` the name of the file without the path
-                ).and(
 * `$canonicalPath` the canonical path
 
 
@@ -2444,7 +2444,6 @@ In the format you can use the following placeholders:
 * `$name` gives the name of the directory as was specified on the macro
 * `$absolutePath` gives the name of the directory as was specified on the macro
 * `$parent` the parent directory
-                ).and(
 * `$canonicalPath` the canonical path
 
 
@@ -2487,11 +2486,11 @@ The format string can be any string with `$` prefixed placeholders.
 The placeholders that the macro handles are:
 
 
-* `$simpleName` will be replaced by the result of calling `getSimpleName()`
-* `$name` will be replaced by the result of calling `getName()`
-* `$canonicalName` will be replaced by the result of calling `getCanonicalName()`
-* `$packageName` will be replaced by the result of calling `getPackageName()`
-* `$typeName` will be replaced by the result of calling `getTypeName()`
+"$simpleName",
+                    "$name",
+                    "$canonicalName",
+                    "$packageName",
+                    "$typeName"
 
 
 For example
@@ -2565,7 +2564,6 @@ The placeholders that the macro handles are:
 * `$packageName` will be replaced by the package where the method is
 * `$typeClass` will be replaced by the type of the field
 * `$modifiers` will be replaced by the modifiers list of the method
-                
 * `$value` will be replaced by the value of the field in case the field is both `static` and `final`
 
 

--- a/jamal-snippet/README.adoc.jam
+++ b/jamal-snippet/README.adoc.jam
@@ -1602,7 +1602,7 @@ results
 
 [[listDir]]
 ==== {%macroChapter%}`listDir`
-{%#snip:check file={%JAVA_DIR%}ListDir.java hash=7f68a4d8%}
+{%#snip:check file={%JAVA_DIR%}ListDir.java hash=5a08f7ac%}
 This macro lists the files in a directory and then returns the list of the formatted files.
 The format of the macro is:
 
@@ -1727,7 +1727,7 @@ will result
 - Format.java: 930 bytes
 - Update.java: 3,754 bytes
 - SnipTransform.java: 14,199 bytes
-- FilesMacro.java: 4,883 bytes
+- FilesMacro.java: 5,196 bytes
 - Collect.java: 7,848 bytes
 - SnipFile.java: 680 bytes
 - TrimLines.java: 4,179 bytes
@@ -1744,7 +1744,7 @@ will result
 - KillLines.java: 2,019 bytes
 - SnipLoad.java: 3,530 bytes
 - SnippetStore.java: 10,174 bytes
-- ListDir.java: 5,321 bytes
+- ListDir.java: 5,583 bytes
 - XmlFormat.java: 3,536 bytes
 - SnippetXmlReader.java: 6,607 bytes
 - XmlInsert.java: 6,199 bytes
@@ -1753,7 +1753,7 @@ will result
 - CounterMacro.java: 1,811 bytes
 - SnipList.java: 1,260 bytes
 - XmlDocument.java: 5,656 bytes
-- Java.java: 9,275 bytes
+- Java.java: 10,404 bytes
 - ReplaceLines.java: 3,015 bytes
 - SkipLines.java: 2,544 bytes
 - SnipCheck.java: 5,619 bytes
@@ -1993,7 +1993,7 @@ These are:
 
 [[file]]
 ==== {%macroChapter%}`file`
-{%#snip:check file={%JAVA_DIR%}FilesMacro.java hash=41a12a1a%}
+{%#snip:check file={%JAVA_DIR%}FilesMacro.java hash=228815ff%}
 {%@define fileDirectory($what)=
 You can use this macro to include the name of a $what in the documentation.
 First, it seems counterintuitive to have a macro for that.
@@ -2024,26 +2024,23 @@ When Jamal processes this file it will generate `README.adoc`.
 ----
 %}
 
-{%@define replace=|^.*?"(.*?)"|* `$1`!|!.*?//||%}\
-{%@define pattern=\)\.and\(%}\
 In the format you can use the following placeholders:
+{%@comment the two replaces are executed from left to right. The first one puts a ! after the `xxx` name, and the second one finds it.%}
 {%#snip:define fileMacroFormatPlaceholdersFormatted=
-{%#replaceLines
-{%#killLines
-{%@snip fileMacroFormatPlaceholders %}%}%}%}
+{%#snip:transform replace="|^.*?\"(.*?)\"|* `$1`!|!.*?//||"
+{%@snip fileMacroFormatPlaceholders %}%}%}
 
 {%@snip fileMacroFormatPlaceholdersFormatted
 * `$name` gives the name of the file as was specified on the macro
 * `$absolutePath` the absolute path to the file
 * `$parent` the parent directory where the file is
 * `$simpleName` the name of the file without the path
-                ).and(
 * `$canonicalPath` the canonical path
 %}
 
 [[directory]]
 ==== {%macroChapter%}`directory`
-{%#snip:check file={%JAVA_DIR%}FilesMacro.java hash=b569430d%}
+{%#snip:check file={%JAVA_DIR%}FilesMacro.java hash=b8519137%}
 {%fileDirectory directory%}
 
 {%sample/
@@ -2062,22 +2059,20 @@ This file is in the directory `../jamal-snippet`.
 
 In the format you can use the following placeholders:
 {%#snip:define dirMacroFormatPlaceholdersFormatted=
-{%#replaceLines
-{%#killLines
-{%@snip dirMacroFormatPlaceholders %}%}%}%}
+{%#snip:transform replace="|^.*?\"(.*?)\"|* `$1`!|!.*?//||"
+{%@snip dirMacroFormatPlaceholders %}%}%}
 
 {%@snip dirMacroFormatPlaceholdersFormatted
 * `$name` gives the name of the directory as was specified on the macro
 * `$absolutePath` gives the name of the directory as was specified on the macro
 * `$parent` the parent directory
-                ).and(
 * `$canonicalPath` the canonical path
 %}
 
 
 [[Java]]
 ==== {%macroChapter%}Java Macros
-{%#snip:check file={%JAVA_DIR%}Java.java hash=3f795145%}
+{%#snip:check file={%JAVA_DIR%}Java.java hash=42188e24%}
 
 [[java:class]]
 ===== `java:class`
@@ -2117,11 +2112,11 @@ The placeholders that the macro handles are:
 {%#snip:define classFormatFormatted={%#replaceLines
 {%@snip classFormats%}%}%}
 {%@snip classFormatFormatted
-* `$simpleName` will be replaced by the result of calling `getSimpleName()`
-* `$name` will be replaced by the result of calling `getName()`
-* `$canonicalName` will be replaced by the result of calling `getCanonicalName()`
-* `$packageName` will be replaced by the result of calling `getPackageName()`
-* `$typeName` will be replaced by the result of calling `getTypeName()`
+"$simpleName",
+                    "$name",
+                    "$canonicalName",
+                    "$packageName",
+                    "$typeName"
 %}
 
 For example
@@ -2194,7 +2189,6 @@ of the field
 * `$packageName` will be replaced by the package where the method is
 * `$typeClass` will be replaced by the type of the field
 * `$modifiers` will be replaced by the modifiers list of the method
-                
 * `$value` will be replaced by the value of the field in case the field is both `static` and `final`
 %}
 

--- a/jamal-snippet/src/main/java/javax0/jamal/snippet/Java.java
+++ b/jamal-snippet/src/main/java/javax0/jamal/snippet/Java.java
@@ -6,19 +6,32 @@ import javax0.jamal.api.InnerScopeDependent;
 import javax0.jamal.api.Input;
 import javax0.jamal.api.Macro;
 import javax0.jamal.api.Processor;
+import javax0.jamal.tools.IndexedPlaceHolders;
+import javax0.jamal.tools.IndexedPlaceHolders.ThrowingStringSupplier;
 import javax0.jamal.tools.InputHandler;
 import javax0.jamal.tools.Params;
-import javax0.jamal.tools.PlaceHolders;
-import javax0.jamal.tools.Trie;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static javax0.jamal.tools.IndexedPlaceHolders.value;
+
 public class Java {
 
     public static class ClassMacro implements Macro, InnerScopeDependent {
+        private static class Trie {
+            static IndexedPlaceHolders formatter = IndexedPlaceHolders.with(
+                    // snippet classFormats
+                    "$simpleName",
+                    "$name",
+                    "$canonicalName",
+                    "$packageName",
+                    "$typeName"
+                    // end snippet
+            );
+        }
 
         @Override
         public String evaluate(Input in, Processor processor) throws BadSyntax {
@@ -28,15 +41,13 @@ public class Java {
             final var className = in.toString().trim();
             try {
                 final var klass = Class.forName(className);
-                return PlaceHolders.with(
-                    // snippet classFormats
-                    "$simpleName", klass.getSimpleName(),
-                    "$name", klass.getName(),
-                    "$canonicalName", klass.getCanonicalName(),
-                    "$packageName", klass.getPackageName(),
-                    "$typeName", klass.getTypeName()
-                    // end snippet
-                ).format(format.get());
+                return Trie.formatter.format(format.get(),
+                        klass.getSimpleName(),
+                        klass.getName(),
+                        klass.getCanonicalName(),
+                        klass.getPackageName(),
+                        klass.getTypeName()
+                );
             } catch (Exception e) {
                 throw new BadSyntaxAt("The class '" + className + "' cannot be found on the classpath in the macro '" + getId() + "'.", in.getPosition(), e);
             }
@@ -49,6 +60,23 @@ public class Java {
     }
 
     public static class FieldMacro implements Macro, InnerScopeDependent {
+        private static class Trie {
+            static IndexedPlaceHolders formatter = IndexedPlaceHolders.with(
+                    // OTFDC -> of the field's defining class
+                    // OTF -> of the field
+                    // snippet fieldFormats
+                    "$name",// name OTF
+                    "$classSimpleName",// simple name OTFDC
+                    "$className",// name of the OTFDC
+                    "$classCanonicalName",// canonical name OTFDC
+                    "$classTypeName",// type name OTFDC
+                    "$packageName",// package where the method is
+                    "$typeClass",// type OTF
+                    "$modifiers",// modifiers list of the method
+                    "$value"// value OTF in case the field is both `static` and `final`
+                    // end snippet
+            );
+        }
 
         @Override
         public String evaluate(Input in, Processor processor) throws BadSyntax {
@@ -72,7 +100,7 @@ public class Java {
             } catch (Exception e) {
                 throw new BadSyntaxAt("The field '" + fieldRef + "' cannot be found on the classpath in the macro '" + getId() + "'.", in.getPosition(), e);
             }
-            final Trie.ThrowingStringSupplier valueCalculator;
+            final ThrowingStringSupplier valueCalculator;
             if (Modifier.isStatic(field.getModifiers()) && Modifier.isFinal(field.getModifiers())) {
                 valueCalculator = () -> "" + field.get(null);
             } else {
@@ -81,22 +109,17 @@ public class Java {
                 };
             }
             try {
-                return PlaceHolders.with(
-                    // OTFDC -> of the field's defining class
-                    // OTF -> of the field
-                    // snippet fieldFormats
-                    "$name", field.getName(), // name OTF
-                    "$classSimpleName", klass.getSimpleName(), // simple name OTFDC
-                    "$className", klass.getName(), // name of the OTFDC
-                    "$classCanonicalName", klass.getCanonicalName(),// canonical name OTFDC
-                    "$classTypeName", klass.getTypeName(), // type name OTFDC
-                    "$packageName", klass.getPackageName(), // package where the method is
-                    "$typeClass", field.getType().getName(), // type OTF
-                    "$modifiers", Modifier.toString(field.getModifiers()) // modifiers list of the method
-                ).and(
-                    "$value", valueCalculator // value OTF in case the field is both `static` and `final`
-                    // end snippet
-                ).format(format.get());
+                return Trie.formatter.format(format.get(),
+                        value(field.getName()),
+                        value(klass.getSimpleName()),
+                        value(klass.getName()),
+                        value(klass.getCanonicalName()),
+                        value(klass.getTypeName()),
+                        value(klass.getPackageName()),
+                        value(field.getType().getName()),
+                        value(Modifier.toString(field.getModifiers())),
+                        value(valueCalculator)
+                );
             } catch (Exception e) {
                 throw new BadSyntax("Cannot evaluate field formatting for '" + fieldRef + "' using '" + format.get() + "'", e);
             }
@@ -109,13 +132,32 @@ public class Java {
     }
 
     public static class MethodMacro implements Macro, InnerScopeDependent {
+        private static class Trie {
+            static IndexedPlaceHolders formatter = IndexedPlaceHolders.with(
+                    // OTMDC -> of the method's defining class
+                    // OTM -> of the method
+                    // snippet methodFormats
+                    "$classSimpleName",// simple name OTMDC
+                    "$className",// name of the OTMDC
+                    "$classCanonicalName",// canonical name OTMDC
+                    "$classTypeName",// type name OTMDC
+                    "$packageName",// package where the method is
+                    "$name",// name OTM
+                    "$typeClass",// return type OTM
+                    "$exceptions",// comma separated values of the exception types the method throws
+                    "$parameterTypes",// comma separated parameter types
+                    "$parameterCount",// number of the parameters in decimal format
+                    "$modifiers"// modifiers list of the method
+                    // end snippet
+            );
+        }
 
         @Override
         public String evaluate(Input in, Processor processor) throws BadSyntax {
             final var pos = in.getPosition();
             final var format = Params.<String>holder("methodFormat", "format").orElse("$name");
             Params.using(processor).from(this).between("()").keys(format).parse(in);
-            final var parts = split(in,this);
+            final var parts = split(in, this);
             final var className = parts[0];
             final var methodName = parts[1];
             final Class<?> klass;
@@ -126,27 +168,23 @@ public class Java {
             }
 
             final var method = Arrays.stream(klass.getDeclaredMethods()).filter(m -> m.getName().equals(methodName)).findAny().orElseThrow(
-                () -> new BadSyntaxAt("The method '" + methodName + "' cannot be found in the class '" + className + "' in the macro '" + getId() + "'.", in.getPosition())
+                    () -> new BadSyntaxAt("The method '" + methodName + "' cannot be found in the class '" + className + "' in the macro '" + getId() + "'.", in.getPosition())
             );
             try {
-                return PlaceHolders.with(
-                    // OTMDC -> of the method's defining class
-                    // OTM -> of the method
-                    // snippet methodFormats
-                    "$classSimpleName", klass.getSimpleName(), // simple name OTMDC
-                    "$className", klass.getName(), // name of the OTMDC
-                    "$classCanonicalName", klass.getCanonicalName(),// canonical name OTMDC
-                    "$classTypeName", klass.getTypeName(), // type name OTMDC
-                    "$packageName", klass.getPackageName(), // package where the method is
-                    "$name", method.getName(), // name OTM
-                    "$typeClass", method.getReturnType().getName(), // return type OTM
-                    "$exceptions", Arrays.stream(method.getExceptionTypes()).map(Class::getName).collect(Collectors.joining(",")), // comma separated values of the exception types the method throws
-                    "$parameterTypes", Arrays.stream(method.getParameterTypes()).map(Class::getName).collect(Collectors.joining(",")),// comma separated parameter types
-                    "$parameterCount", "" + method.getParameterCount(), // number of the parameters in decimal format
-                    "$modifiers", Modifier.toString(method.getModifiers() // modifiers list of the method
-                        // end snippet
-                    )
-                ).format(format.get());
+                return Trie.formatter.format(format.get(),
+                        klass.getSimpleName(),
+                        klass.getName(),
+                        klass.getCanonicalName(),
+                        klass.getTypeName(),
+                        klass.getPackageName(),
+                        method.getName(),
+                        method.getReturnType().getName(),
+                        Arrays.stream(method.getExceptionTypes()).map(Class::getName).collect(Collectors.joining(",")),
+                        Arrays.stream(method.getParameterTypes()).map(Class::getName).collect(Collectors.joining(",")),
+                        "" + method.getParameterCount(),
+                        Modifier.toString(method.getModifiers()
+                        )
+                );
             } catch (Exception e) {//can't really happen as we only have string values for the placeholders
                 throw new BadSyntaxAt("There is an exception formatting the method '" + methodName + "' ", pos, e);
             }

--- a/jamal-tools/src/main/java/javax0/jamal/tools/GenericTrie.java
+++ b/jamal-tools/src/main/java/javax0/jamal/tools/GenericTrie.java
@@ -2,51 +2,62 @@ package javax0.jamal.tools;
 
 import java.util.Optional;
 
-public class Trie {
-    private final Node root = new Node();
+public class GenericTrie<T> {
+    private final Node<T> root = new Node<>();
     private static final int OFFSET = '!';
 
-    public interface ThrowingStringSupplier {
-        String get() throws Exception;
-    }
-
-    private static class Node {
-        String value;
-        ThrowingStringSupplier supplier;
+    private static class Node<T> {
+        T value;
         boolean leaf = false;
-        final private Node[] letters = new Node['~' - OFFSET + 1];
+        final private Node<T>[] letters = (Node<T>[]) new Node['~' - OFFSET + 1];
     }
 
-    public static class Result {
+    public static class Result<T> {
         public final int start;
         public final int end;
-        public final String value;
+        public final T value;
 
-        private Result(int start, int end, Node node) throws Exception {
+        private Result(int start, int end, Node<T> node) {
             this.start = start;
             this.end = end;
-            if (node.value == null && node.supplier != null) {
-                node.value = node.supplier.get();
-            }
             this.value = node.value;
         }
     }
 
-    public Optional<Result> find(CharSequence key) throws Exception {
+    public Optional<Result<T>> find(CharSequence key) throws Exception {
         return find(key, 0);
     }
 
-    public Optional<Result> find(CharSequence key, int start) throws Exception {
+    @Override
+    public String toString() {
+        final var sb = new StringBuilder();
+        _toString("", sb, root);
+        return sb.toString();
+    }
+
+    private void _toString(String prefix, StringBuilder sb, Node<T> node) {
+        if( node.leaf){
+            sb.append(prefix).append(" -> ").append(node.value).append("\n");
+        }else{
+            for (int i = 0; i < node.letters.length; i++) {
+                if( node.letters[i] != null ){
+                    _toString(prefix + (char)(i + OFFSET), sb, node.letters[i]);
+                }
+            }
+        }
+    }
+
+    public Optional<Result<T>> find(CharSequence key, int start) throws Exception {
         final var chars = key.toString().toCharArray();
         while (start < key.length()) {
             int end = start;
-            Node node = root;
+            Node<T> node = root;
             while (node != null) {
                 if (end >= chars.length || node.leaf) {
                     if (!node.leaf) {
                         return Optional.empty();
                     } else {
-                        return Optional.of(new Result(start, end, node));
+                        return Optional.of(new Result<>(start, end, node));
                     }
                 }
                 final var index = chars[end] - OFFSET;
@@ -62,23 +73,15 @@ public class Trie {
         return Optional.empty();
     }
 
-    public String get(String key) throws Exception {
+    public T get(String key) throws Exception {
         return find(key).map(f -> f.value).orElse(null);
     }
 
-    public void put(String key, String value) {
-        put(key, value, null);
-    }
-
-    public void put(String key, ThrowingStringSupplier value) {
-        put(key, null, value);
-    }
-
-    private void put(String key, String value, ThrowingStringSupplier supplier) {
+    public void put(String key, T value) {
         final var chars = key.toCharArray();
         int i = 0;
-        Node node = root;
-        Node parent = null;
+        Node<T> node = root;
+        Node<T> parent = null;
         while (node != null) {
             if (i >= chars.length) {
                 throw new IllegalArgumentException("The key '" + key + "' is already in the trie.");
@@ -101,12 +104,11 @@ public class Trie {
             if (index < 0 || index >= parent.letters.length) {
                 throw new IllegalArgumentException("Characters in the string can only be between ! and ~ (33-126) in '" + key + "'");
             }
-            parent.letters[index] = new Node();
+            parent.letters[index] = new Node<>();
             parent = parent.letters[index];
             i++;
         }
         parent.value = value;
-        parent.supplier = supplier;
         parent.leaf = true;
     }
 }

--- a/jamal-tools/src/main/java/javax0/jamal/tools/IndexedPlaceHolders.java
+++ b/jamal-tools/src/main/java/javax0/jamal/tools/IndexedPlaceHolders.java
@@ -1,0 +1,122 @@
+package javax0.jamal.tools;
+
+import java.util.Arrays;
+
+/**
+ * Replace the placeholders to the actual values in strings. The placeholders are searched from left to right in the
+ * string and are replaced one after the other. The string that gets into the place of the placeholder will not be
+ * searched for additional placeholders.
+ * <p>
+ * Placeholders are specified as strings and the replacement can be specified either as  string or as a string supplier.
+ * The supplier may throw an exception.
+ */
+public class IndexedPlaceHolders {
+
+    private final GenericTrie<Integer> trie = new GenericTrie<>();
+
+    /**
+     * The simple implementation of the placeholder functionality that does not handle suppliers. This implementation
+     * formally is the extension of the more complex one because and not the other way around. The whole hocus pocus
+     * with the class extensions is to let two different {@link IndexedPlaceHolders#format(String, Value...)} replace()}
+     * methods. One that throws exception and the other one that does not.
+     *
+     * @param keys the key of the placeholder
+     * @return a placeholder implementation
+     */
+    public static IndexedPlaceHolders with(String... keys) {
+        return new IndexedPlaceHolders(keys);
+    }
+
+    private IndexedPlaceHolders(String... keys) {
+        for (int i = 0; i < keys.length; i++) {
+            this.trie.put(keys[i], i);
+        }
+    }
+
+    public interface ThrowingStringSupplier {
+        String get() throws Exception;
+    }
+
+    public static class Value {
+        private String value;
+        private final ThrowingStringSupplier supplier;
+
+        public Value(final String value, final ThrowingStringSupplier supplier) {
+            this.value = value;
+            this.supplier = supplier;
+        }
+
+        public String get() throws Exception {
+            if (value == null) {
+                value = supplier.get();
+            }
+            return value;
+        }
+    }
+
+    public static Value value(String value) {
+        return new Value(value, null);
+    }
+
+    public static Value value(ThrowingStringSupplier supplier) {
+        return new Value(null, supplier);
+    }
+
+    public Value[] values(Value... vs) {
+        return vs;
+    }
+
+    /**
+     * Replace the placeholders in the string {@code format} with the values from the maps and return the result.
+     * <p>
+     * The placeholders and the values are stored in two maps. The keys in the maps are the placeholder strings, and the
+     * values are used to get the string to replace the placeholders with.
+     * <p>
+     * One map contains strings as values. The other one contains string suppliers. These suppliers are NOT {@link
+     * java.util.function.Supplier}s because they may throw an exception. Any of the suppliers are invoked only if there
+     * is a need for them. This is an important feature, because it means that there will be no exception in case the
+     * placeholder to be replaced by the result of the supplier is not used even if the supplier would throw an
+     * exception.
+     * <p>
+     * Any of the suppliers are invoked at most once, when they are referenced the first time. After that the result is
+     * stored in the string value map and used from there. Consecutive invocation of {@code format()} will use the
+     * already calculated value.
+     * <p>
+     * Placeholder replacement starts from the left to the right and replacement texts are not scanned for placeholders.
+     * For example:
+     *
+     * <pre>{@code
+     *   PlaceHolders.of("$a", "$b", "$b", "$a").format("$a $b")
+     * }</pre>
+     * <p>
+     * will become
+     *
+     * <pre>{@code
+     * "$b $a"
+     * }</pre>
+     *
+     * @param original the format string with the placeholders
+     * @param values   the values to replace the placeholders with
+     * @return the formatted string
+     * @throws Exception if one of the evaluated supplier throws exception
+     */
+    public String format(final String original, Value... values) throws Exception {
+        StringBuilder sb = new StringBuilder(original);
+        int doneIndex = 0;
+        while (true) {
+            final var found = trie.find(sb, doneIndex);
+            if (found.isPresent()) {
+                final String actualValue = values[found.get().value].get();
+                sb.replace(found.get().start, found.get().end, actualValue);
+                doneIndex = found.get().start + actualValue.length();
+            } else {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    public String format(final String original, final String... values) throws Exception {
+        return format(original, Arrays.stream(values).map(s -> value(s)).toArray(Value[]::new));
+    }
+}

--- a/jamal-tools/src/main/java/javax0/jamal/tools/Trie.java
+++ b/jamal-tools/src/main/java/javax0/jamal/tools/Trie.java
@@ -1,0 +1,112 @@
+package javax0.jamal.tools;
+
+import java.util.Optional;
+
+public class Trie {
+    private final Node root = new Node();
+    private static final int OFFSET = '!';
+
+    public interface ThrowingStringSupplier {
+        String get() throws Exception;
+    }
+
+    private static class Node {
+        String value;
+        ThrowingStringSupplier supplier;
+        boolean leaf = false;
+        final private Node[] letters = new Node['~' - OFFSET + 1];
+    }
+
+    public static class Result {
+        public final int start;
+        public final int end;
+        public final String value;
+
+        private Result(int start, int end, Node node) throws Exception {
+            this.start = start;
+            this.end = end;
+            if (node.value == null && node.supplier != null) {
+                node.value = node.supplier.get();
+            }
+            this.value = node.value;
+        }
+    }
+
+    public Optional<Result> find(CharSequence key) throws Exception {
+        return find(key, 0);
+    }
+
+    public Optional<Result> find(CharSequence key, int start) throws Exception {
+        final var chars = key.toString().toCharArray();
+        while (start < key.length()) {
+            int end = start;
+            Node node = root;
+            while (node != null) {
+                if (end >= chars.length || node.leaf) {
+                    if (!node.leaf) {
+                        return Optional.empty();
+                    } else {
+                        return Optional.of(new Result(start, end, node));
+                    }
+                }
+                final var index = chars[end] - OFFSET;
+                if (index >= 0 && index < node.letters.length) {
+                    node = node.letters[index];
+                } else {
+                    node = null;
+                }
+                end++;
+            }
+            start++;
+        }
+        return Optional.empty();
+    }
+
+    public String get(String key) throws Exception {
+        return find(key).map(f -> f.value).orElse(null);
+    }
+
+    public void put(String key, String value) {
+        put(key, value, null);
+    }
+
+    public void put(String key, ThrowingStringSupplier value) {
+        put(key, null, value);
+    }
+
+    private void put(String key, String value, ThrowingStringSupplier supplier) {
+        final var chars = key.toCharArray();
+        int i = 0;
+        Node node = root;
+        Node parent = null;
+        while (node != null) {
+            if (i >= chars.length) {
+                throw new IllegalArgumentException("The key '" + key + "' is already in the trie.");
+            }
+            final var index = chars[i] - OFFSET;
+            if (index < 0 || index >= node.letters.length) {
+                throw new IllegalArgumentException("Characters in the string can only be between ! and ~ (33-126) in '" + key + "'");
+            }
+            parent = node;
+            node = node.letters[index];
+            if (node != null) {
+                i++;
+            }
+        }
+        if (parent.leaf) {
+            throw new IllegalArgumentException("The key '" + key + "' has a prefix '" + key.substring(0, i) + "' in the trie.");
+        }
+        while (i < chars.length) {
+            final var index = chars[i] - OFFSET;
+            if (index < 0 || index >= parent.letters.length) {
+                throw new IllegalArgumentException("Characters in the string can only be between ! and ~ (33-126) in '" + key + "'");
+            }
+            parent.letters[index] = new Node();
+            parent = parent.letters[index];
+            i++;
+        }
+        parent.value = value;
+        parent.supplier = supplier;
+        parent.leaf = true;
+    }
+}

--- a/jamal-tools/src/test/java/javax0/jamal/tools/TestGenericTrie.java
+++ b/jamal-tools/src/test/java/javax0/jamal/tools/TestGenericTrie.java
@@ -1,0 +1,108 @@
+package javax0.jamal.tools;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class TestGenericTrie {
+
+
+    @Test
+    @DisplayName("Finds a single element put in as string")
+    void testGet() throws Exception {
+        final var sut = new GenericTrie<Integer>();
+        sut.put("a", 13);
+        Assertions.assertEquals((Integer) 13, sut.get("a"));
+    }
+
+    @Test
+    @DisplayName("Null values can also be inserted")
+    void testNull() throws Exception {
+        final var sut = new GenericTrie<Integer>();
+        sut.put("a", null);
+        Assertions.assertNull(sut.get("a"));
+    }
+
+    @Test
+    @DisplayName("get() return null for non-existent key")
+    void testNotFind() throws Exception {
+        final var sut = new GenericTrie<Integer>();
+        sut.put("a", 13);
+        Assertions.assertNull(sut.get("b"));
+    }
+
+    @Test
+    @DisplayName("Throws for illegal character")
+    void testIllegalCharacter1() {
+        final var sut = new GenericTrie<Integer>();
+        sut.put("a", 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("\n", 1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("a\n", 1));
+        sut.put("ba", 1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("bc\n", 1));
+
+    }
+
+    @Test
+    @DisplayName("The map stores and finds example keys")
+    void testMultipleExamples() throws Exception {
+        final var sut = new GenericTrie<Integer>();
+        sut.put("a", 1);
+        sut.put("ba", 1);
+        sut.put("bb", 1);
+        sut.put("bca", 1);
+        sut.put("bda", 1);
+        sut.put("bdc", 1);
+
+        Assertions.assertEquals((Integer)1, sut.get("a"));
+        Assertions.assertEquals((Integer)1, sut.get("ba"));
+        Assertions.assertEquals((Integer)1, sut.get("bb"));
+        Assertions.assertEquals((Integer)1, sut.get("bca"));
+        Assertions.assertEquals((Integer)1, sut.get("bda"));
+        Assertions.assertEquals((Integer)1, sut.get("bdc"));
+    }
+
+    @Test
+    @DisplayName("Throws exception when key prefix each other")
+    void testThrowsForPrefix() {
+        final var sut = new GenericTrie<String>();
+        sut.put("bca", "bca");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("bcad", "bcad"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("bc", "bc"));
+    }
+
+    @Test
+    @DisplayName("Throws exception when key prefix each other even when the values are null")
+    void testThrowsForPrefixForNullValues() {
+        final var sut = new GenericTrie<String>();
+        sut.put("bca", (String) null);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("bcad", (String) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sut.put("bc", (String) null));
+    }
+
+    @Test
+    @DisplayName("The map stores and finds example keys")
+    void testFind() throws Exception {
+        final var sut = new GenericTrie<String>();
+        sut.put("a", "a");
+        sut.put("ba", "ba");
+        sut.put("bb", "bb");
+        sut.put("bca", "bca");
+        sut.put("bda", "bda");
+        sut.put("bdc", "bdc");
+
+        final var result1 = sut.find("abba");
+
+        //noinspection OptionalGetWithoutIsPresent
+        Assertions.assertEquals(0, result1.get().start);
+        Assertions.assertEquals(1, result1.get().end);
+        final var s = "\nkirbgobdchuppa";
+        final var result2 = sut.find(s);
+        //noinspection OptionalGetWithoutIsPresent
+        Assertions.assertEquals("bdc", s.substring(result2.get().start, result2.get().end));
+
+        final var result3 = sut.find("sssspppbc");
+        Assertions.assertFalse(result3.isPresent());
+    }
+
+}

--- a/jamal-tools/src/test/java/javax0/jamal/tools/TestIndexedPlaceHolders.java
+++ b/jamal-tools/src/test/java/javax0/jamal/tools/TestIndexedPlaceHolders.java
@@ -6,90 +6,116 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class TestPlaceHolders {
+import static javax0.jamal.tools.IndexedPlaceHolders.value;
+
+public class TestIndexedPlaceHolders {
+
+    private static class Format {
+        IndexedPlaceHolders iph;
+        String[] values;
+
+        String format(String string) throws Exception {
+            return iph.format(string, values);
+        }
+    }
+
+    private Format with(String... strings) {
+        final var f = new Format();
+        final var keys = new String[strings.length / 2];
+        f.values = new String[strings.length / 2];
+        for (int i = 0; i < strings.length; i += 2) {
+            keys[i / 2] = strings[i];
+            f.values[i / 2] = strings[i + 1];
+        }
+        f.iph = IndexedPlaceHolders.with(keys);
+        return f;
+    }
 
     @Test
     @DisplayName("Works in the simple case")
     void testPlaceHolderReplace() throws Exception {
         Assertions.assertEquals("a , b , b , b , $c",
-            PlaceHolders.with("$a", "a", "$b", "b").format("$a , $b , $b , $b , $c"));
+                with("$a", "a", "$b", "b").format("$a , $b , $b , $b , $c"));
     }
 
     @Test
     @DisplayName("Does not replace replaced code documentation")
     void testPlaceHolderReplaceComplex0() throws Exception {
         Assertions.assertEquals("$b $a",
-            PlaceHolders.with("$a", "$b", "$b", "$a").format("$a $b"));
+                with("$a", "$b", "$b", "$a").format("$a $b"));
     }
 
     @Test
     @DisplayName("Does not replace replaced code")
     void testPlaceHolderReplaceComplex() throws Exception {
         Assertions.assertEquals("a , b , $b",
-            PlaceHolders.with("$a", "a", "$b", "b").format("$a , $b , $$b"));
+                with("$a", "a", "$b", "b").format("$a , $b , $$b"));
     }
 
     @Test
     @DisplayName("Works on empty input string")
     void testEmpty() throws Exception {
         Assertions.assertEquals("",
-            PlaceHolders.with("$a", "a", "$b", "b").format(""));
+                with("$a", "a", "$b", "b").format(""));
     }
 
     @Test
     @DisplayName("Works with empty map")
     void testEmptyMap() throws Exception {
         Assertions.assertEquals("abraka dabra",
-            PlaceHolders.with().format("abraka dabra"));
+                with().format("abraka dabra"));
     }
 
     @Test
     @DisplayName("Works on string with empty map")
     void testEmptyAll() throws Exception {
         Assertions.assertEquals("",
-            PlaceHolders.with().format(""));
+                with().format(""));
     }
 
     @Test
     @DisplayName("Does not skip placeholder after long placeholder")
     void testWorksWithLongerValue() throws Exception {
         Assertions.assertEquals("$b $a",
-            PlaceHolders.with("$thisIsAReallyLongPlaceHolder", "$b", "$b", "$a").format("$thisIsAReallyLongPlaceHolder $b"));
+                with("$thisIsAReallyLongPlaceHolder", "$b", "$b", "$a").format("$thisIsAReallyLongPlaceHolder $b"));
         Assertions.assertEquals("this is a long value that at the end contains a placeholder like string $b $a",
-            PlaceHolders.with("$a", "this is a long value that at the end contains a placeholder like string $b", "$b", "$a").format("$a $b"));
+                with("$a", "this is a long value that at the end contains a placeholder like string $b", "$b", "$a").format("$a $b"));
     }
 
     @Test
     @DisplayName("Does not replace back and forth")
     void testVeryComplex() throws Exception {
         Assertions.assertEquals("$b $a",
-            PlaceHolders.with("$a", "$b", "$b", "$a").format("$a $b"));
+                with("$a", "$b", "$b", "$a").format("$a $b"));
     }
 
     @Test
     @DisplayName("Does not throw supplier exception when the placeholder is not used")
     void testNotThrowing() throws Exception {
+        final var formatter = IndexedPlaceHolders.with("$a", "$b");
         Assertions.assertEquals("$b $b",
-            PlaceHolders.with("$a", "$b").and("$b", () -> {
-                throw new Exception();
-            }).format("$a $a"));
+                formatter.format("$a $a", value("$b"), value(() -> {
+                    throw new Exception();
+                })));
     }
 
     @Test
     @DisplayName("Throws exception when the placeholder is used")
     void testThrowing() {
-        Assertions.assertThrows(Exception.class, () ->
-            PlaceHolders.with("$a", "$b").and("$b", () -> {
-                throw new Exception();
-            }).format("$a $b"));
+        final var formatter = IndexedPlaceHolders.with("$a", "$b");
+        Assertions.assertThrows(Exception.class,() ->
+                formatter.format("$a $b", value("$b"), value(() -> {
+                    throw new Exception();
+                })));
     }
 
     @Test
     @DisplayName("Supplier is evaluated only once")
     void testEvalOnce() throws Exception {
         final var i = new AtomicInteger(1);
+        final var formatter = IndexedPlaceHolders.with("$a");
         Assertions.assertEquals("1 1",
-            PlaceHolders.with().and("$a", () -> "" + i.getAndAdd(1)).format("$a $a"));
+                formatter.format("$a $a", value( () -> "" + i.getAndAdd(1))));
     }
 
 }


### PR DESCRIPTION
Trie handling is optimized. This means that the Tries are not rebuilt every time, they become public static final immutable structures. Instead of the actual values, the IndexedPlaceHolders uses fixed indices and these are used to index the actual values (String or supplier) in an array when formatting.

The old versions are still there to support the old version of PlantUML that uses this and is part o the dependency graph as a test dependency.